### PR TITLE
Use dep ranges

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,26 +34,26 @@
     "stylint": "./bin/stylint"
   },
   "devDependencies": {
-    "chai": "3.5.0",
-    "eslint": "2.13.1",
-    "istanbul": "0.4.3",
-    "jsdoc": "3.4.2",
-    "mocha": "2.5.3",
-    "sinon": "1.17.4",
-    "touch": "1.0.0"
+    "chai": "^3.5.0",
+    "eslint": "^2.13.1",
+    "istanbul": "^0.4.3",
+    "jsdoc": "^3.4.2",
+    "mocha": "^2.5.3",
+    "sinon": "^1.17.4",
+    "touch": "^1.0.0"
   },
   "dependencies": {
-    "async": "1.5.2",
-    "chalk": "1.1.3",
-    "chokidar": "1.5.2",
-    "columnify": "1.5.4",
-    "glob": "7.0.4",
-    "lodash.defaults": "4.0.1",
-    "path-is-absolute": "1.0.0",
-    "stampit": "1.2.0",
-    "strip-json-comments": "2.0.1",
-    "user-home": "2.0.0",
-    "yargs": "4.7.1"
+    "async": "^1.5.2",
+    "chalk": "^1.1.3",
+    "chokidar": "^1.5.2",
+    "columnify": "^1.5.4",
+    "glob": "^7.0.4",
+    "lodash.defaults": "^4.0.1",
+    "path-is-absolute": "^1.0.0",
+    "stampit": "^1.2.0",
+    "strip-json-comments": "^2.0.1",
+    "user-home": "^2.0.0",
+    "yargs": "^4.7.1"
   },
   "scripts": {
     "cover": "istanbul cover node_modules/.bin/_mocha -- -u exports -R spec test/test.js",


### PR DESCRIPTION
I read that this was gonna be in v2, but that was a few months ago and the fixed versions are making it really hard to dedupe shared dependencies btwn stylint and other packages. Not sure if there was a reason for specific fixed versions but the tests pass with the ranges.