### PR TITLE
Fix：Remove useless `path` reference

### DIFF
--- a/src/core/cache.js
+++ b/src/core/cache.js
@@ -1,5 +1,3 @@
-var path = require( 'path' )
-
 // the main cache object
 var cache = {
 	col: null, // column number for warning if applicable


### PR DESCRIPTION
Remove the declaration of 'path' in the 'cache.js', due to a warning
when running `npm run test`：

![image](https://user-images.githubusercontent.com/40081831/53387907-044c6700-39c4-11e9-835d-a3325acef469.png)
