### PR TITLE
Fix for Node.js 11

### DIFF
--- a/src/checks/sortOrder.js
+++ b/src/checks/sortOrder.js
@@ -71,6 +71,10 @@ var sortOrder = function( line ) {
 			var bIndex = orderingArr.indexOf( b )
 
 			// allow properties that don't exist in ordering array to be last
+			if ( aIndex < 0 ) {
+				aIndex = orderingArr.length
+			}
+
 			if ( bIndex < 0 ) {
 				bIndex = orderingArr.length
 			}


### PR DESCRIPTION
The `sortOrder()` function appears to make an assumption about custom
sort functions that isn't true in the V8 shipped with Node.js 11. As a
result, tests fail in Node.js 11, and probably code in the wild fails
too. This fixes the function to be compatible with Node.js 11.

This will also mean that Travis should now start passing again.