### PR TITLE
chore: Update various dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "chai": "3.5.0",
     "eslint": "2.13.1",
     "jsdoc": "3.6.2",
-    "mocha": "2.5.3",
+    "mocha": "4.1.0",
     "nyc": "14.1.1",
     "sinon": "1.17.4",
     "touch": "1.0.0"
@@ -45,7 +45,7 @@
   "dependencies": {
     "async": "1.5.2",
     "chalk": "1.1.3",
-    "chokidar": "3.0.1",
+    "chokidar": "3.0.2",
     "columnify": "1.5.4",
     "glob": "7.0.4",
     "lodash.defaults": "4.2.0",
@@ -55,12 +55,12 @@
     "yargs": "4.7.1"
   },
   "scripts": {
-    "cover": "nyc mocha",
+    "cover": "nyc mocha --exit",
     "docs": "jsdoc src/ --recurse --destination docs/",
     "lint": "eslint .",
     "precover": "npm run lint",
     "pretest": "npm run lint",
     "start": "node --harmony index.js",
-    "test": "mocha"
+    "test": "mocha --exit"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -212,7 +212,7 @@ describe( 'Core Methods: ', function() {
 
 		beforeEach( function() {
 			app.watcher = undefined
-			app.state.path = 'fhqwhgads' // Chokidar throws without a path.
+			app.state.path = '.' // Chokidar throws without a path.
 		} )
 
 		it( 'should be a function', function() {

--- a/test/test.js
+++ b/test/test.js
@@ -212,6 +212,7 @@ describe( 'Core Methods: ', function() {
 
 		beforeEach( function() {
 			app.watcher = undefined
+			app.state.path = 'fhqwhgads' // Chokidar throws without a path.
 		} )
 
 		it( 'should be a function', function() {


### PR DESCRIPTION
Update dev dependencies:

* istanbul 0.4.3 -> 0.4.5
* jsdoc 3.4.2 -> 3.6.2
* mocha 2.5.3 -> 6.1.4

Update dependency:

* chokidar 1.5.2 -> 3.0.2

The mocha udpate required a small change to the test file as mocha no
longer forces an exit once all tests have passed. So a file had to be
unwatched after the relevant test passed, or otherwise mocha would not
exit.

These updates resolve all warnings from `npm audit` on a fresh clone of the repository.